### PR TITLE
Single source of truth for ruby version

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2.3' # Matches your Gemfile
+          ruby-file: .ruby-version
           bundler-cache: true # Runs 'bundle install' and caches gems automatically
       - name: Setup Pages
         id: pages

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
-ruby "3.2.3"
+
+# single source of truth for ruby version
+ruby file: ".ruby-version"
 
 gem "jekyll"
 


### PR DESCRIPTION
Use the `.ruby-version` file as SOT for all stuff.