### PR TITLE
Fix mobile viewport distortion during headshot rotation

### DIFF
--- a/assets/css/sparkly-header.scss
+++ b/assets/css/sparkly-header.scss
@@ -13,6 +13,11 @@ body {
   padding:0;
 }
 
+html, body {
+  overflow-x: clip;
+  overscroll-behavior-x: none;
+}
+
 section#main{
   display:inline-block;
 }
@@ -24,7 +29,7 @@ section#sparkly-header {
   min-height:50vh;
   background-repeat:no-repeat;
   background-size:cover;
-  background-attachment:fixed;
+  overflow: hidden;
 }
 
 section#sparkly-header{


### PR DESCRIPTION
On mobile, clicking the headshot triggers an elastic-spin animation
(720deg over 0.7s). Combined with the confetti burst, transient
horizontal overflow caused mobile browsers to auto-scale the viewport
down to fit, leaving a white margin on the right and shrinking the
whole page mid-animation.

Fixes:

- overflow-x: clip on html, body. Prevents any transient overflow
  from triggering the mobile-browser zoom-to-fit behavior. Using
  'clip' instead of 'hidden' so neither element becomes a scroll
  container, which would otherwise interfere with sweet-scroll's
  smooth-scroll and with iOS momentum scrolling.
- overflow: hidden on section#sparkly-header. Contains the rotating
  image's bounding box and any particles painting inside it.
- Removed background-attachment: fixed. There is no background image
  set, so the property was a no-op, and 'fixed' is a known iOS
  Safari trigger for viewport repaint glitches during transforms.