### PR TITLE
Add /game — clickable, swipeable, occasionally infernal

### DIFF
--- a/_includes/sparkly_header.html
+++ b/_includes/sparkly_header.html
@@ -58,7 +58,10 @@
         {% endif %}
       </div>
       <div class="header-links">
-        <!-- <a class="link" href="#about" data-scroll>About Me</a> -->
+        <a class="hero-cta" href="{{ "/game" | relative_url }}">
+          <i class="fa fa-gamepad" aria-hidden="true"></i>
+          Wanna play?
+        </a>
       </div>
   </div>
   <a class="down" href="#main" data-scroll><i class="icon fa fa-chevron-down" aria-hidden="true"></i></a>

--- a/_includes/sparkly_header.html
+++ b/_includes/sparkly_header.html
@@ -60,7 +60,7 @@
       <div class="header-links">
         <a class="hero-cta" href="{{ "/game" | relative_url }}">
           <i class="fa fa-gamepad" aria-hidden="true"></i>
-          Wanna play?
+          Play a game
         </a>
       </div>
   </div>

--- a/assets/css/game.css
+++ b/assets/css/game.css
@@ -1,0 +1,545 @@
+.headshot-game {
+  width: 100%;
+  max-width: 720px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.headshot-game__intro h1 {
+  margin-bottom: 8px;
+}
+.headshot-game__intro p {
+  color: #5b6472;
+  margin-top: 0;
+}
+
+.headshot-game.is-negative .headshot-game__intro h1::after {
+  content: ' 👹';
+  display: inline-block;
+  margin-left: 8px;
+  transform-origin: center;
+  animation: demon-wobble 1.4s ease-in-out infinite;
+}
+@keyframes demon-wobble {
+  0%, 100% { transform: rotate(-8deg) scale(1); }
+  50%      { transform: rotate(8deg) scale(1.12); }
+}
+
+.headshot-game__board {
+  position: relative;
+  margin: 32px 0;
+}
+
+.headshot-game__stats {
+  display: flex;
+  justify-content: center;
+  gap: 24px;
+  margin-bottom: 28px;
+  flex-wrap: wrap;
+}
+
+.headshot-game__stats .stat {
+  background: #fff;
+  border: 1px solid rgba(26, 34, 44, 0.08);
+  border-radius: 14px;
+  padding: 12px 20px;
+  min-width: 110px;
+  box-shadow: 0 2px 8px rgba(26, 34, 44, 0.04);
+}
+
+.stat__label {
+  display: block;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #5b6472;
+}
+
+.stat__value {
+  display: block;
+  font-family: 'Montserrat', sans-serif;
+  font-size: 28px;
+  font-weight: 700;
+  color: #1a222c;
+  line-height: 1.1;
+  margin-top: 4px;
+  font-variant-numeric: tabular-nums;
+}
+
+.stat__value.negative {
+  color: #e64545;
+}
+
+#game-clicks {
+  cursor: pointer;
+  user-select: none;
+  transition: text-shadow 0.2s ease, transform 0.2s ease;
+}
+#game-clicks:hover {
+  text-shadow: 0 0 14px rgba(40, 91, 177, 0.35);
+}
+#game-clicks:active {
+  transform: scale(0.95);
+}
+
+.stat__value.bump {
+  animation: stat-bump 0.35s ease;
+}
+@keyframes stat-bump {
+  0%   { transform: scale(1); }
+  50%  { transform: scale(1.18); color: var(--main-color-1, #285BB1); }
+  100% { transform: scale(1); }
+}
+
+.headshot-game__target {
+  appearance: none;
+  -webkit-appearance: none;
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: grab;
+  position: relative;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  outline: none;
+  touch-action: none;
+  user-select: none;
+  -webkit-user-select: none;
+}
+.headshot-game__target:focus-visible .headshot-game__card {
+  box-shadow: 0 0 0 3px rgba(40, 91, 177, 0.5);
+}
+
+.headshot-game__card {
+  position: relative;
+  display: inline-block;
+  border-radius: 50%;
+  width: 280px;
+  height: 280px;
+  max-width: 60vw;
+  max-height: 60vw;
+  transition: transform 0.45s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.headshot-game__target.dragging {
+  cursor: grabbing;
+}
+.headshot-game__target.dragging .headshot-game__card {
+  transition: none;
+}
+
+.headshot-game__target.swipe-right .headshot-game__card {
+  animation: swipe-fly-right 0.65s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+.headshot-game__target.swipe-left .headshot-game__card {
+  animation: swipe-fly-left 0.65s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+.headshot-game__target.swipe-up .headshot-game__card {
+  animation: swipe-fly-up 0.65s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+.headshot-game__target.swipe-down .headshot-game__card {
+  animation: swipe-fly-down 0.65s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+@keyframes swipe-fly-right {
+  0%   { transform: translateX(0) rotate(0deg); }
+  35%  { transform: translateX(220px) rotate(22deg); opacity: 0.85; }
+  60%  { transform: translateX(220px) rotate(22deg); opacity: 0; }
+  61%  { transform: translateX(-40px) rotate(-6deg); opacity: 0; }
+  100% { transform: translateX(0) rotate(0deg); opacity: 1; }
+}
+@keyframes swipe-fly-left {
+  0%   { transform: translateX(0) rotate(0deg); }
+  35%  { transform: translateX(-220px) rotate(-22deg); opacity: 0.85; }
+  60%  { transform: translateX(-220px) rotate(-22deg); opacity: 0; }
+  61%  { transform: translateX(40px) rotate(6deg); opacity: 0; }
+  100% { transform: translateX(0) rotate(0deg); opacity: 1; }
+}
+@keyframes swipe-fly-up {
+  0%   { transform: translateY(0); }
+  35%  { transform: translateY(-200px); opacity: 0.85; }
+  60%  { transform: translateY(-200px); opacity: 0; }
+  61%  { transform: translateY(40px); opacity: 0; }
+  100% { transform: translateY(0); opacity: 1; }
+}
+@keyframes swipe-fly-down {
+  0%   { transform: translateY(0); }
+  35%  { transform: translateY(200px); opacity: 0.85; }
+  60%  { transform: translateY(200px); opacity: 0; }
+  61%  { transform: translateY(-40px); opacity: 0; }
+  100% { transform: translateY(0); opacity: 1; }
+}
+
+body.rage-mode {
+  animation: rage-shake 0.5s cubic-bezier(0.36, 0.07, 0.19, 0.97) 6;
+}
+body.rage-mode::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background:
+    radial-gradient(circle at 50% 35%, rgba(255, 30, 30, 0.55) 0%, rgba(180, 0, 0, 0.55) 35%, rgba(60, 0, 0, 0.85) 100%);
+  pointer-events: none;
+  z-index: 9999;
+  animation: rage-storm 3s ease-out forwards;
+}
+body.rage-mode::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background: #fff;
+  pointer-events: none;
+  z-index: 10000;
+  opacity: 0;
+  animation: rage-lightning 3s steps(1) forwards;
+}
+@keyframes rage-shake {
+  0%, 100% { transform: translate(0, 0) rotate(0); }
+  10%      { transform: translate(-7px, 3px) rotate(-0.7deg); }
+  20%      { transform: translate(7px, -3px) rotate(0.7deg); }
+  30%      { transform: translate(-6px, 5px) rotate(-0.5deg); }
+  40%      { transform: translate(6px, -5px) rotate(0.6deg); }
+  50%      { transform: translate(-5px, 3px) rotate(-0.4deg); }
+  60%      { transform: translate(5px, -3px) rotate(0.5deg); }
+  70%      { transform: translate(-4px, 2px) rotate(-0.3deg); }
+  80%      { transform: translate(4px, -2px) rotate(0.3deg); }
+  90%      { transform: translate(-2px, 1px) rotate(-0.2deg); }
+}
+@keyframes rage-storm {
+  0%   { opacity: 0; }
+  10%  { opacity: 1; }
+  25%  { opacity: 0.85; }
+  40%  { opacity: 1; }
+  55%  { opacity: 0.8; }
+  70%  { opacity: 0.95; }
+  85%  { opacity: 0.7; }
+  100% { opacity: 0; }
+}
+@keyframes rage-lightning {
+  0%, 6%   { opacity: 0; }
+  7%       { opacity: 0.85; }
+  9%       { opacity: 0; }
+  10%      { opacity: 0.6; }
+  12%      { opacity: 0; }
+  34%      { opacity: 0; }
+  35%      { opacity: 0.75; }
+  37%      { opacity: 0; }
+  58%      { opacity: 0; }
+  59%      { opacity: 0.7; }
+  61%      { opacity: 0; }
+  78%      { opacity: 0; }
+  79%      { opacity: 0.55; }
+  81%      { opacity: 0; }
+  100%     { opacity: 0; }
+}
+
+.swipe-label {
+  position: absolute;
+  top: 14%;
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 800;
+  font-size: 26px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 8px 16px;
+  border: 3px solid currentColor;
+  border-radius: 10px;
+  pointer-events: none;
+  opacity: 0;
+  transform: rotate(-12deg);
+  transition: opacity 0.15s ease;
+}
+.swipe-label--like {
+  right: 14%;
+  color: #1bb46a;
+  transform: rotate(-12deg);
+}
+.swipe-label--nope {
+  left: 14%;
+  color: #e64545;
+  transform: rotate(12deg);
+}
+.headshot-game__target.dragging .swipe-label {
+  opacity: var(--label-opacity, 0);
+}
+
+.emoji-burst {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  font-size: 28px;
+  pointer-events: none;
+  opacity: 0;
+  animation: emoji-fly 1.1s ease-out forwards;
+  animation-delay: var(--delay, 0ms);
+  will-change: transform, opacity;
+}
+@keyframes emoji-fly {
+  0%   { opacity: 1; transform: translate(-50%, -50%) scale(0.4) rotate(0); }
+  20%  { opacity: 1; transform: translate(calc(-50% + var(--dx, 0px) * 0.3), calc(-50% + var(--dy, 0px) * 0.3)) scale(1.1); }
+  100% { opacity: 0; transform: translate(calc(-50% + var(--dx, 0px)), calc(-50% + var(--dy, 0px))) rotate(var(--rot, 0deg)) scale(1.2); }
+}
+
+.headshot-game__card img {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  object-fit: cover;
+  display: block;
+  background: #1a222c;
+  box-shadow:
+    0 0 0 4px rgba(40, 91, 177, 0.08),
+    0 0 0 1px rgba(26, 34, 44, 0.12),
+    0 18px 50px rgba(26, 34, 44, 0.18),
+    0 0 60px rgba(40, 91, 177, 0.18);
+  transition: box-shadow 0.3s ease;
+  pointer-events: none;
+}
+
+.headshot-game__target:hover .headshot-game__card img {
+  box-shadow:
+    0 0 0 6px rgba(40, 91, 177, 0.12),
+    0 0 0 1px rgba(26, 34, 44, 0.18),
+    0 22px 60px rgba(26, 34, 44, 0.22),
+    0 0 80px rgba(40, 91, 177, 0.28);
+}
+
+.headshot-game__target.spin .headshot-game__card img {
+  animation: game-spin 0.7s ease-in-out;
+}
+@keyframes game-spin {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(720deg); }
+}
+
+.headshot-game__hint {
+  display: inline-block;
+  pointer-events: none;
+  margin-top: 16px;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(40, 91, 177, 0.1);
+  color: var(--main-color-1, #285BB1);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+.headshot-game__target.has-clicked .headshot-game__hint {
+  opacity: 0;
+  transform: translateY(-4px);
+  pointer-events: none;
+}
+
+.headshot-game__feedback {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: visible;
+}
+.headshot-game__feedback .pop {
+  position: absolute;
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 700;
+  font-size: 22px;
+  color: var(--main-color-1, #285BB1);
+  text-shadow: 0 2px 12px rgba(255,255,255,0.8);
+  animation: pop-up 0.9s ease-out forwards;
+  white-space: nowrap;
+}
+.headshot-game__feedback .pop--slow {
+  animation-duration: 1.8s;
+}
+@keyframes pop-up {
+  0%   { opacity: 0; transform: translate(-50%, 0) scale(0.8); }
+  20%  { opacity: 1; transform: translate(-50%, -10px) scale(1.1); }
+  100% { opacity: 0; transform: translate(-50%, -80px) scale(1); }
+}
+
+.headshot-game__achievements {
+  list-style: none;
+  padding: 0;
+  margin: 32px 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 10px;
+}
+
+.headshot-game__achievements li {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  background: #f6f8fb;
+  border: 1px solid rgba(26, 34, 44, 0.06);
+  border-radius: 12px;
+  text-align: left;
+  opacity: 0.45;
+  filter: grayscale(0.6);
+  transition: opacity 0.4s ease, filter 0.4s ease, background 0.4s ease, transform 0.4s ease;
+}
+
+.headshot-game__achievements li.unlocked {
+  opacity: 1;
+  filter: none;
+  background: #fff;
+  border-color: rgba(40, 91, 177, 0.25);
+  box-shadow: 0 4px 14px rgba(40, 91, 177, 0.08);
+}
+
+.headshot-game__achievements li.ach--secret {
+  display: none;
+}
+.headshot-game__achievements li.ach--secret.unlocked {
+  display: flex;
+  background: linear-gradient(135deg, #fff5f0 0%, #ffe6db 100%);
+  border-color: rgba(255, 59, 31, 0.4);
+  box-shadow: 0 4px 14px rgba(255, 59, 31, 0.15);
+}
+.headshot-game__achievements li.ach--secret.unlocked .ach__text strong {
+  color: #ff3b1f;
+}
+
+.headshot-game__achievements li.just-unlocked {
+  animation: ach-pop 0.6s ease;
+}
+@keyframes ach-pop {
+  0%   { transform: scale(1); }
+  40%  { transform: scale(1.06); }
+  100% { transform: scale(1); }
+}
+
+.ach__icon {
+  font-size: 22px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.ach__text {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.2;
+}
+.ach__text strong {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 700;
+  color: #1a222c;
+  font-size: 14px;
+}
+.ach__text em {
+  font-style: normal;
+  font-size: 12px;
+  color: #5b6472;
+  margin-top: 2px;
+}
+
+.headshot-game__controls {
+  margin-top: 24px;
+}
+
+.headshot-game__reset {
+  appearance: none;
+  border: 1px solid rgba(26, 34, 44, 0.15);
+  background: #fff;
+  color: #5b6472;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  padding: 8px 16px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+.headshot-game__reset:hover {
+  background: #1a222c;
+  color: #fff;
+  border-color: #1a222c;
+}
+
+/* Hell mode — persistent while clicks <= -100 */
+body.hell-mode::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 9990;
+  background:
+    radial-gradient(circle at 50% 30%, rgba(255, 30, 30, 0.3) 0%, rgba(180, 0, 0, 0.38) 45%, rgba(60, 0, 0, 0.6) 100%);
+  animation: hell-pulse 2.4s ease-in-out infinite;
+}
+@keyframes hell-pulse {
+  0%, 100% { opacity: 0.55; }
+  50%      { opacity: 1; }
+}
+
+.hell-demons {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 9991;
+  overflow: hidden;
+}
+.hell-demon {
+  position: absolute;
+  bottom: -120px;
+  filter:
+    drop-shadow(0 0 14px rgba(255, 90, 0, 0.85))
+    drop-shadow(0 0 28px rgba(255, 30, 0, 0.65))
+    drop-shadow(0 0 50px rgba(255, 0, 0, 0.4));
+  opacity: 0;
+  animation: hell-drift linear infinite;
+}
+@keyframes hell-drift {
+  0%   { transform: translateY(0) translateX(0) rotate(-6deg); opacity: 0; }
+  10%  { opacity: 0.85; }
+  50%  { transform: translateY(-55vh) translateX(40px) rotate(4deg); opacity: 0.95; }
+  90%  { opacity: 0.7; }
+  100% { transform: translateY(-115vh) translateX(-30px) rotate(-3deg); opacity: 0; }
+}
+
+.unicorn-flyover {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 9998;
+  overflow: hidden;
+}
+.unicorn {
+  position: absolute;
+  left: -120px;
+  font-size: 48px;
+  filter: drop-shadow(0 0 16px rgba(255, 110, 199, 0.55)) drop-shadow(0 0 28px rgba(160, 125, 255, 0.35));
+  animation: unicorn-fly linear forwards;
+}
+.unicorn::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  right: 100%;
+  width: 220px;
+  height: 14px;
+  margin-top: -7px;
+  background: linear-gradient(to right,
+    rgba(160, 125, 255, 0) 0%,
+    rgba(160, 125, 255, 0.55) 18%,
+    rgba(77, 208, 255, 0.6) 35%,
+    rgba(101, 217, 111, 0.6) 52%,
+    rgba(255, 227, 77, 0.6) 70%,
+    rgba(255, 110, 199, 0.65) 100%);
+  border-radius: 999px;
+  filter: blur(2px);
+}
+@keyframes unicorn-fly {
+  0%   { transform: translateX(0) translateY(0) rotate(-4deg); }
+  25%  { transform: translateX(30vw) translateY(-26px) rotate(3deg); }
+  50%  { transform: translateX(60vw) translateY(0) rotate(-3deg); }
+  75%  { transform: translateX(90vw) translateY(-26px) rotate(3deg); }
+  100% { transform: translateX(125vw) translateY(0) rotate(0); }
+}
+
+@media (max-width: 560px) {
+  .headshot-game__stats { gap: 12px; }
+  .headshot-game__stats .stat { padding: 10px 14px; min-width: 90px; }
+  .stat__value { font-size: 22px; }
+}

--- a/assets/css/sparkly-header.scss
+++ b/assets/css/sparkly-header.scss
@@ -308,6 +308,46 @@ section#sparkly-header{
   50%      { transform: translate(-50%, -30%); opacity: 1; }
 }
 
+section#sparkly-header {
+  .header-links {
+    margin-top: 18px;
+    display: flex;
+    justify-content: center;
+  }
+
+  .hero-cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 20px;
+    border-radius: 999px;
+    color: #fff;
+    text-decoration: none;
+    font-family: 'Montserrat', sans-serif;
+    font-size: 15px;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    background: rgba(255, 255, 255, 0.06);
+    border: 1.5px solid rgba(255, 255, 255, 0.45);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+  .hero-cta i {
+    font-size: 14px;
+    opacity: 0.9;
+  }
+  .hero-cta:hover,
+  .hero-cta:focus {
+    background: #fff;
+    color: #1a222c;
+    border-color: #fff;
+    transform: translateY(-2px);
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.3), 0 0 30px rgba(40, 91, 177, 0.4);
+    -webkit-text-stroke: 0;
+  }
+}
+
 /* Design Regular header */
 section#regular-header {
   display: flex;

--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -1,0 +1,537 @@
+(function () {
+  const target = document.getElementById('game-target');
+  if (!target) return;
+
+  const STORAGE_KEY = 'headshotGame.v1';
+  const clicksEl = document.getElementById('game-clicks');
+  const lifetimeEl = document.getElementById('game-lifetime');
+  const feedbackEl = document.getElementById('game-feedback');
+  const achList = document.getElementById('game-achievements');
+  const resetBtn = document.getElementById('game-reset');
+  const gameRoot = document.querySelector('.headshot-game');
+
+  const state = loadState();
+  const thresholds = Array.from(achList.querySelectorAll('li'))
+    .map(li => parseInt(li.dataset.threshold, 10))
+    .sort((a, b) => a - b);
+
+  render();
+
+  const SWIPE_THRESHOLD = 90;
+  const CLICK_MAX_MOVE = 8;
+  const card = document.getElementById('game-card') || target;
+  const drag = { active: false, startX: 0, startY: 0, dx: 0, dy: 0 };
+  let suppressClickUntil = 0;
+  let consecutiveUps = 0;
+
+  target.addEventListener('pointerdown', onPointerDown);
+  target.addEventListener('click', onClick);
+  resetBtn.addEventListener('click', onReset);
+  clicksEl.addEventListener('click', onSecretClick);
+  window.addEventListener('blur', endDrag);
+  document.addEventListener('visibilitychange', function () {
+    if (document.hidden) endDrag();
+  });
+
+  function loadState() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return defaults();
+      const parsed = JSON.parse(raw);
+      return Object.assign(defaults(), parsed);
+    } catch (e) {
+      return defaults();
+    }
+  }
+  function defaults() {
+    return { clicks: 0, lifetime: 0, unlocked: [], unlockedSecrets: [], rageCount: 0, secretClicks: 0 };
+  }
+  function persist() {
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(state)); } catch (e) {}
+  }
+
+  function render() {
+    updateClicksDisplay();
+    updateLifetimeDisplay();
+    if (state.clicks !== 0) target.classList.add('has-clicked');
+    achList.querySelectorAll('li[data-threshold]').forEach(li => {
+      const t = parseInt(li.dataset.threshold, 10);
+      if (state.unlocked.includes(t)) li.classList.add('unlocked');
+    });
+    (state.unlockedSecrets || []).forEach(id => {
+      const li = achList.querySelector('li[data-secret="' + id + '"]');
+      if (li) li.classList.add('unlocked');
+    });
+    checkAchievements();
+  }
+
+  function updateClicksDisplay() {
+    clicksEl.textContent = state.clicks.toLocaleString();
+    clicksEl.classList.toggle('negative', state.clicks < 0);
+    if (gameRoot) gameRoot.classList.toggle('is-negative', state.clicks < 0);
+    toggleHellMode(state.clicks <= -100);
+  }
+
+  function toggleHellMode(on) {
+    const isOn = document.body.classList.contains('hell-mode');
+    if (on === isOn) return;
+    document.body.classList.toggle('hell-mode', on);
+    if (on) spawnHellDemons();
+    else removeHellDemons();
+  }
+
+  function spawnHellDemons() {
+    if (document.getElementById('hell-demons')) return;
+    const container = document.createElement('div');
+    container.id = 'hell-demons';
+    container.className = 'hell-demons';
+    container.setAttribute('aria-hidden', 'true');
+    const glyphs = ['👹', '😈', '👺', '💀', '🔥'];
+    for (let i = 0; i < 9; i++) {
+      const d = document.createElement('span');
+      d.className = 'hell-demon';
+      d.textContent = glyphs[i % glyphs.length];
+      d.style.left = (Math.random() * 95) + 'vw';
+      d.style.fontSize = (32 + Math.random() * 56) + 'px';
+      d.style.animationDuration = (10 + Math.random() * 8) + 's';
+      d.style.animationDelay = (-Math.random() * 18) + 's';
+      container.appendChild(d);
+    }
+    document.body.appendChild(container);
+  }
+
+  function removeHellDemons() {
+    const c = document.getElementById('hell-demons');
+    if (c) c.remove();
+  }
+
+  function updateLifetimeDisplay() {
+    lifetimeEl.textContent = state.lifetime.toLocaleString();
+    lifetimeEl.classList.toggle('negative', state.lifetime < 0);
+  }
+
+  function onPointerDown(e) {
+    if (drag.active) endDrag();
+    drag.active = true;
+    drag.pointerId = e.pointerId;
+    drag.startX = e.clientX;
+    drag.startY = e.clientY;
+    drag.dx = 0;
+    drag.dy = 0;
+    try { target.setPointerCapture(e.pointerId); } catch (_) {}
+    target.classList.add('dragging');
+    document.addEventListener('pointermove', onPointerMove);
+    document.addEventListener('pointerup', onPointerUp);
+    document.addEventListener('pointercancel', onPointerUp);
+  }
+
+  function onPointerMove(e) {
+    if (!drag.active) return;
+    if (drag.pointerId != null && e.pointerId !== drag.pointerId) return;
+    drag.dx = e.clientX - drag.startX;
+    drag.dy = e.clientY - drag.startY;
+    const rot = Math.max(-16, Math.min(16, drag.dx * 0.05));
+    card.style.transform = 'translate(' + drag.dx + 'px, ' + (drag.dy * 0.3) + 'px) rotate(' + rot + 'deg)';
+    const ratio = Math.min(1, Math.abs(drag.dx) / SWIPE_THRESHOLD);
+    const likeLabel = card.querySelector('.swipe-label--like');
+    const nopeLabel = card.querySelector('.swipe-label--nope');
+    if (likeLabel) likeLabel.style.setProperty('--label-opacity', drag.dx > 0 ? ratio : 0);
+    if (nopeLabel) nopeLabel.style.setProperty('--label-opacity', drag.dx < 0 ? ratio : 0);
+  }
+
+  function onPointerUp(e) {
+    if (!drag.active) return;
+    if (drag.pointerId != null && e && e.pointerId !== drag.pointerId) return;
+    const dx = drag.dx;
+    const dy = drag.dy;
+    endDrag(e);
+
+    const dist = Math.hypot(dx, dy);
+    let dir = null;
+    if (dist >= SWIPE_THRESHOLD) {
+      const angle = Math.atan2(dy, dx) * 180 / Math.PI;
+      if (angle >= -45 && angle < 45) dir = 'right';
+      else if (angle >= 45 && angle < 135) dir = 'down';
+      else if (angle >= -135 && angle < -45) dir = 'up';
+      else dir = 'left';
+    }
+    if (dir) {
+      suppressClickUntil = Date.now() + 250;
+      triggerSwipe(dir);
+    } else if (dist > CLICK_MAX_MOVE) {
+      suppressClickUntil = Date.now() + 250;
+    }
+  }
+
+  function endDrag(e) {
+    if (!drag.active) {
+      cleanupDragListeners();
+      return;
+    }
+    drag.active = false;
+    if (drag.pointerId != null) {
+      try { target.releasePointerCapture(drag.pointerId); } catch (_) {}
+    }
+    drag.pointerId = null;
+    target.classList.remove('dragging');
+    const likeLabel = card.querySelector('.swipe-label--like');
+    const nopeLabel = card.querySelector('.swipe-label--nope');
+    if (likeLabel) likeLabel.style.removeProperty('--label-opacity');
+    if (nopeLabel) nopeLabel.style.removeProperty('--label-opacity');
+    card.style.transform = '';
+    cleanupDragListeners();
+  }
+
+  function cleanupDragListeners() {
+    document.removeEventListener('pointermove', onPointerMove);
+    document.removeEventListener('pointerup', onPointerUp);
+    document.removeEventListener('pointercancel', onPointerUp);
+  }
+
+  function triggerSwipe(dir) {
+    target.classList.remove('swipe-right', 'swipe-left', 'swipe-up', 'swipe-down');
+    void target.offsetWidth;
+    target.classList.add('swipe-' + dir);
+    target.addEventListener('animationend', function handler(ev) {
+      if (ev.animationName.indexOf('swipe-fly-') === 0) {
+        target.classList.remove('swipe-right', 'swipe-left', 'swipe-up', 'swipe-down');
+        target.removeEventListener('animationend', handler);
+      }
+    });
+
+    let delta = 0;
+    let lifetimeDelta = 0;
+    let popText = '';
+    let popColor = '#285BB1';
+    let emoji = '✨';
+    let signX = 0, signY = -1;
+    let rage = false;
+
+    if (dir === 'right') {
+      delta = 5; lifetimeDelta = 5;
+      popText = '+5 Liked!'; popColor = '#1bb46a';
+      emoji = '💚'; signX = 1; signY = -1;
+      consecutiveUps = 0;
+    } else if (dir === 'left') {
+      delta = 5; lifetimeDelta = 5;
+      popText = '+5 Nope!'; popColor = '#e64545';
+      emoji = '🍅'; signX = -1; signY = -1;
+      consecutiveUps = 0;
+    } else if (dir === 'up') {
+      delta = -10; lifetimeDelta = -10;
+      popText = '-10 BAD!'; popColor = '#e64545';
+      emoji = '💢'; signX = 0; signY = -1;
+      consecutiveUps += 1;
+      const rageThreshold = ((state.rageCount || 0) + 1) * 3;
+      if (consecutiveUps >= rageThreshold) {
+        rage = true;
+        delta = -25;
+        lifetimeDelta = -25;
+        popText = '-25 RAGE!!!'; popColor = '#ff3b1f';
+        emoji = '🤬'; signX = 0; signY = 0;
+        consecutiveUps = 0;
+        state.rageCount = (state.rageCount || 0) + 1;
+        unlockSecret('rage');
+      }
+    } else if (dir === 'down') {
+      delta = -10; lifetimeDelta = -10;
+      popText = '-10 BAD!'; popColor = '#e64545';
+      emoji = '💢'; signX = 0; signY = 1;
+      consecutiveUps = 0;
+    }
+
+    state.clicks = state.clicks + delta;
+    state.lifetime = state.lifetime + lifetimeDelta;
+    bumpStat(clicksEl);
+    if (lifetimeDelta) bumpStat(lifetimeEl);
+    updateClicksDisplay();
+    updateLifetimeDisplay();
+    checkAchievements();
+    persist();
+
+    const rect = target.getBoundingClientRect();
+    spawnPopAt({
+      x: rect.left + rect.width / 2,
+      y: rect.top + rect.height * 0.18,
+      text: popText,
+      color: popColor
+    });
+    spawnEmojiBurst(emoji, signX, signY);
+
+    if (rage) {
+      triggerRage(rect);
+    } else if (typeof window.confetti === 'function' && (dir === 'right' || dir === 'left')) {
+      const x = (rect.left + rect.right) / 2 / window.innerWidth;
+      const y = (rect.top + rect.bottom) / 2 / window.innerHeight;
+      window.confetti({
+        particleCount: 60,
+        spread: 60,
+        startVelocity: 35,
+        origin: { x, y },
+        colors: dir === 'right'
+          ? ['#1bb46a', '#7be0a6', '#ffffff']
+          : ['#e64545', '#ffb3b3', '#ffffff']
+      });
+    }
+  }
+
+  function triggerRage(rect) {
+    document.body.classList.add('rage-mode');
+    setTimeout(function () { document.body.classList.remove('rage-mode'); }, 3000);
+
+    const stormEmojis = ['🤬', '💢', '😡', '⚡', '🌩️'];
+    for (let i = 0; i < 6; i++) {
+      setTimeout(function () {
+        spawnEmojiBurst(stormEmojis[i % stormEmojis.length], 0, 0);
+      }, i * 350);
+    }
+
+    if (typeof window.confetti === 'function') {
+      const ragePalette = ['#ff0000', '#ff3b1f', '#cc0000', '#990000', '#ff8a1f', '#000000'];
+      const baseX = (rect.left + rect.right) / 2 / window.innerWidth;
+      const baseY = (rect.top + rect.bottom) / 2 / window.innerHeight;
+      for (let i = 0; i < 5; i++) {
+        setTimeout(function () {
+          window.confetti({
+            particleCount: 90,
+            spread: 360,
+            startVelocity: 55,
+            origin: {
+              x: Math.max(0.1, Math.min(0.9, baseX + (Math.random() * 0.3 - 0.15))),
+              y: Math.max(0.1, Math.min(0.9, baseY + (Math.random() * 0.3 - 0.15)))
+            },
+            colors: ragePalette
+          });
+        }, i * 500);
+      }
+    }
+  }
+
+  function spawnEmojiBurst(emoji, signX, signY) {
+    const count = signX === 0 && signY === 0 ? 16 : 10;
+    const fbRect = feedbackEl.getBoundingClientRect();
+    const targetRect = target.getBoundingClientRect();
+    const cx = (targetRect.left + targetRect.width / 2) - fbRect.left;
+    const cy = (targetRect.top + targetRect.height / 2) - fbRect.top;
+    for (let i = 0; i < count; i++) {
+      const el = document.createElement('span');
+      el.className = 'emoji-burst';
+      el.textContent = emoji;
+      el.style.left = cx + 'px';
+      el.style.top = cy + 'px';
+      const dx = signX === 0
+        ? (Math.random() * 360 - 180)
+        : signX * (60 + Math.random() * 160);
+      const dy = signY === 0
+        ? (Math.random() * 360 - 180)
+        : signY * (40 + Math.random() * 160);
+      el.style.setProperty('--dx', dx + 'px');
+      el.style.setProperty('--dy', dy + 'px');
+      el.style.setProperty('--rot', (Math.random() * 720 - 360) + 'deg');
+      el.style.setProperty('--delay', (i * 30) + 'ms');
+      feedbackEl.appendChild(el);
+      setTimeout(function () { el.remove(); }, 1300 + i * 30);
+    }
+  }
+
+  function spawnPopAt(opts) {
+    const fbRect = feedbackEl.getBoundingClientRect();
+    const pop = document.createElement('span');
+    pop.className = 'pop' + (opts.slow ? ' pop--slow' : '');
+    pop.style.left = (opts.x - fbRect.left) + 'px';
+    pop.style.top = (opts.y - fbRect.top) + 'px';
+    if (opts.color) pop.style.color = opts.color;
+    pop.textContent = opts.text;
+    feedbackEl.appendChild(pop);
+    setTimeout(function () { pop.remove(); }, opts.slow ? 1800 : 900);
+  }
+
+  function onClick(e) {
+    if (Date.now() < suppressClickUntil) return;
+    consecutiveUps = 0;
+    state.clicks += 1;
+    state.lifetime += 1;
+    target.classList.add('has-clicked');
+
+    bumpStat(clicksEl);
+    bumpStat(lifetimeEl);
+
+    spawnPop(e);
+    spinIfDue();
+    confettiIfDue();
+    checkAchievements();
+    persist();
+    updateClicksDisplay();
+    updateLifetimeDisplay();
+  }
+
+  function onReset() {
+    state.clicks = 0;
+    state.unlocked = [];
+    state.secretClicks = 0;
+    consecutiveUps = 0;
+    persist();
+    updateClicksDisplay();
+    achList.querySelectorAll('li[data-threshold]').forEach(li => li.classList.remove('unlocked'));
+    target.classList.remove('has-clicked');
+  }
+
+  function onSecretClick(e) {
+    e.stopPropagation();
+    state.secretClicks = (state.secretClicks || 0) + 1;
+    const n = state.secretClicks;
+    const r = clicksEl.getBoundingClientRect();
+    const popOpts = {
+      x: r.left + r.width / 2,
+      y: r.top + r.height / 2 - 6
+    };
+
+    let delta = 0;
+    let popText = 'ok, no more secret points for you';
+    let popColor = '#5b6472';
+
+    if (n >= 1 && n <= 3) {
+      delta = 5;
+      popText = '+5 😉';
+      popColor = '#1bb46a';
+    } else if (n === 13) {
+      delta = 10;
+      popText = 'Fiiiiine. But no more! +10';
+      popColor = '#1bb46a';
+    } else if (n === 18) {
+      delta = -50;
+      popText = 'I told you no more!! -50';
+      popColor = '#e64545';
+      triggerRage(target.getBoundingClientRect());
+      unlockSecret('rage');
+    }
+
+    if (delta !== 0) {
+      state.clicks += delta;
+      state.lifetime += delta;
+      bumpStat(clicksEl);
+      bumpStat(lifetimeEl);
+      updateClicksDisplay();
+      updateLifetimeDisplay();
+      checkAchievements();
+    }
+    persist();
+    spawnPopAt({ x: popOpts.x, y: popOpts.y, text: popText, color: popColor, slow: true });
+  }
+
+  function bumpStat(el) {
+    el.classList.remove('bump');
+    void el.offsetWidth;
+    el.classList.add('bump');
+  }
+
+  function spawnPop(e) {
+    const rect = target.getBoundingClientRect();
+    const fbRect = feedbackEl.getBoundingClientRect();
+    const x = (e && e.clientX !== undefined ? e.clientX : rect.left + rect.width / 2) - fbRect.left;
+    const y = (e && e.clientY !== undefined ? e.clientY : rect.top + rect.height / 2) - fbRect.top;
+    const pop = document.createElement('span');
+    pop.className = 'pop';
+    pop.style.left = x + 'px';
+    pop.style.top = y + 'px';
+    pop.textContent = labelForClick(state.clicks);
+    feedbackEl.appendChild(pop);
+    setTimeout(() => pop.remove(), 900);
+  }
+
+  function labelForClick(n) {
+    if (n === 1) return 'Hello!';
+    if (n > 0 && n % 100 === 0) return n.toLocaleString() + '!';
+    if (n > 0 && n % 25 === 0) return 'Combo ' + n + '!';
+    return '+1';
+  }
+
+  function spinIfDue() {
+    if (state.clicks <= 0) return;
+    if (state.clicks === 1 || state.clicks % 10 === 0) {
+      target.classList.remove('spin');
+      void target.offsetWidth;
+      target.classList.add('spin');
+      target.addEventListener('animationend', () => {
+        target.classList.remove('spin');
+      }, { once: true });
+    }
+  }
+
+  function confettiIfDue() {
+    if (state.clicks <= 0) return;
+    if (typeof window.confetti !== 'function') return;
+    const isMilestone = state.clicks === 1 || state.clicks % 25 === 0;
+    if (!isMilestone) return;
+    const rect = target.getBoundingClientRect();
+    const x = (rect.left + rect.right) / 2 / window.innerWidth;
+    const y = (rect.top + rect.bottom) / 2 / window.innerHeight;
+    const big = state.clicks % 100 === 0;
+    window.confetti({
+      particleCount: big ? 220 : 120,
+      spread: big ? 100 : 70,
+      startVelocity: big ? 55 : 40,
+      origin: { x, y }
+    });
+  }
+
+  function checkAchievements() {
+    thresholds.forEach(t => {
+      if (state.clicks >= t && !state.unlocked.includes(t)) {
+        state.unlocked.push(t);
+        const li = achList.querySelector('li[data-threshold="' + t + '"]');
+        if (li) {
+          li.classList.add('unlocked', 'just-unlocked');
+          setTimeout(() => li.classList.remove('just-unlocked'), 700);
+        }
+        if (t === 100) triggerUnicornFlyover();
+      }
+    });
+    if (state.clicks <= -100) unlockSecret('abyss');
+  }
+
+  function unlockSecret(id) {
+    state.unlockedSecrets = state.unlockedSecrets || [];
+    if (state.unlockedSecrets.includes(id)) return;
+    state.unlockedSecrets.push(id);
+    const li = achList.querySelector('li[data-secret="' + id + '"]');
+    if (li) {
+      li.classList.add('unlocked', 'just-unlocked');
+      setTimeout(function () { li.classList.remove('just-unlocked'); }, 700);
+    }
+    persist();
+  }
+
+  function triggerUnicornFlyover() {
+    const container = document.createElement('div');
+    container.className = 'unicorn-flyover';
+    const unicornCount = 7;
+    for (let i = 0; i < unicornCount; i++) {
+      const u = document.createElement('span');
+      u.className = 'unicorn';
+      u.textContent = '🦄';
+      u.style.top = (8 + Math.random() * 70) + 'vh';
+      u.style.fontSize = (40 + Math.random() * 36) + 'px';
+      u.style.animationDelay = (i * 280) + 'ms';
+      u.style.animationDuration = (4 + Math.random() * 2.5) + 's';
+      container.appendChild(u);
+    }
+    document.body.appendChild(container);
+    setTimeout(function () { container.remove(); }, 9000);
+
+    if (typeof window.confetti === 'function') {
+      const rainbow = ['#ff6ec7', '#ffb84d', '#ffe34d', '#65d96f', '#4dd0ff', '#a07dff'];
+      [0, 800, 1600].forEach(function (delay) {
+        setTimeout(function () {
+          window.confetti({
+            particleCount: 120,
+            spread: 80,
+            startVelocity: 45,
+            origin: { x: 0.5, y: 0.4 },
+            colors: rainbow
+          });
+        }, delay);
+      });
+    }
+  }
+})();

--- a/pages/game.md
+++ b/pages/game.md
@@ -1,0 +1,60 @@
+---
+layout: default
+title: Game
+permalink: /game
+menus:
+  header:
+    identifier: Game
+    weight: 20
+---
+
+<section class="headshot-game" aria-labelledby="game-heading">
+  <header class="headshot-game__intro">
+    <h1 id="game-heading">Behold, a face.</h1>
+    <p>Strange things may occur.</p>
+  </header>
+
+  <div class="headshot-game__board">
+    <div class="headshot-game__stats" aria-live="polite">
+      <div class="stat">
+        <span class="stat__label">Now</span>
+        <span class="stat__value" id="game-clicks">0</span>
+      </div>
+      <div class="stat">
+        <span class="stat__label">Lifetime</span>
+        <span class="stat__value" id="game-lifetime">0</span>
+      </div>
+    </div>
+
+    <button class="headshot-game__target" id="game-target" type="button" aria-label="Click or swipe my headshot">
+      <span class="headshot-game__card" id="game-card">
+        <span class="swipe-label swipe-label--nope" aria-hidden="true">Nope</span>
+        <span class="swipe-label swipe-label--like" aria-hidden="true">Like</span>
+        <picture>
+          <source srcset="{{ '/images/yaakov-bressler-headshot.webp' | relative_url }}" type="image/webp">
+          <img src="{{ '/images/yaakov-bressler-headshot.jpeg' | relative_url }}" alt="Yaakov Bressler headshot" width="320" height="320" decoding="async">
+        </picture>
+      </span>
+      <span class="headshot-game__hint">Click or swipe</span>
+    </button>
+
+    <div class="headshot-game__feedback" id="game-feedback" aria-hidden="true"></div>
+  </div>
+
+  <ul class="headshot-game__achievements" id="game-achievements">
+    <li data-threshold="1"><span class="ach__icon">👋</span><span class="ach__text"><strong>Hello there</strong><em>First click</em></span></li>
+    <li data-threshold="10"><span class="ach__icon">🔥</span><span class="ach__text"><strong>Warmed up</strong><em>10 clicks</em></span></li>
+    <li data-threshold="25"><span class="ach__icon">🎉</span><span class="ach__text"><strong>Confetti drop</strong><em>25 clicks</em></span></li>
+    <li data-threshold="50"><span class="ach__icon">🚀</span><span class="ach__text"><strong>Lift-off</strong><em>50 clicks</em></span></li>
+    <li data-threshold="100"><span class="ach__icon">💯</span><span class="ach__text"><strong>Centurion</strong><em>100 clicks</em></span></li>
+    <li class="ach--secret" data-secret="rage"><span class="ach__icon">⚡</span><span class="ach__text"><strong>Rage Unlocked</strong><em>Secret</em></span></li>
+    <li class="ach--secret" data-secret="abyss"><span class="ach__icon">💀</span><span class="ach__text"><strong>Rock Bottom</strong><em>Secret</em></span></li>
+  </ul>
+
+  <div class="headshot-game__controls">
+    <button type="button" id="game-reset" class="headshot-game__reset">Reset run</button>
+  </div>
+</section>
+
+<link rel="stylesheet" href="{{ '/assets/css/game.css' | relative_url }}">
+<script defer src="{{ '/assets/js/game.js' | relative_url }}"></script>


### PR DESCRIPTION
## Summary
A new `/game` page wired into the header nav, plus a "Wanna play?" CTA in the home hero linking to it.

The game is a Tinder-style headshot easter egg with persistent local-storage state, achievement unlocks, secret badges, hell mode, and a punishing rage system.

### Mechanics
- **Click** the headshot for +1.
- **Swipe right / left** for +5 with green hearts / red tomatoes and a small confetti burst.
- **Swipe up / down** for -10 (BAD).
- **3 swipe-ups in a row** triggers RAGE: 3-second screen shake + pulsing red overlay + lightning strobe + storm of 🤬 + heavy confetti barrage. Rage **punishes** (-25) and the threshold backs off (3 → 6 → 9 → ...) each time.

### Two stats — both can go negative
- **Now** (current run) — turns red below 0.
- **Lifetime** (running total) — also decreases on punishments. By design.

### Hell mode
- When **Now < 0**, a 👹 wobbles next to the page heading.
- When **Now ≤ -100**, full hell mode: pulsing red gradient overlay + 9 glowing demon glyphs (👹 😈 👺 💀 🔥) drifting up from below. Persistent until you climb back out or hit Reset.

### Visible achievements (per-run, off Now)
- 1 / 10 / 25 / 50 / 100 — unlock with a pop animation.
- At **100 in one run**: 7 rainbow-trailed unicorns fly across the screen with a triple confetti barrage.

### Two secret badges (persist across resets)
- **⚡ Rage Unlocked** — first time you trigger rage.
- **💀 Rock Bottom** — first time you hit -100.

### Secret-secret on the "Now" number
- Click the **Now** number for +5 with 😉 (max 3 times).
- After that: "ok, no more secret points for you".
- Click **that** message **10** more times and it relents: "Fiiiiine. But no more! +10".
- Click it **5** more times and it RAGES: "I told you no more!! -50" with the full storm.

### Engineering notes
- Tinder-style drag transforms only the headshot card (so it stays a perfect circle, never an oval). Direction is computed from the **angle** of the total drag vector, so sloppy diagonal swipes still classify cleanly.
- Pointer handling uses **document-level** pointermove/up/cancel listeners + a window-blur safety reset, so the card never gets stuck if the cursor leaves the headshot mid-drag.
- All state persists via `localStorage`. Reset wipes the run-scoped stuff (Now, in-run achievements, secret-click counter, ups streak). Lifetime, secret badges, and rage backoff persist across resets.

### Less instructional copy
- Page intro: "Behold, a face." / "Strange things may occur."

## Test plan
- [ ] `bundle exec jekyll serve` and visit `/`.
- [ ] Confirm "Wanna play?" CTA appears below social icons in the home hero and links to `/game`.
- [ ] Confirm "Game" appears in the header nav alongside About / Projects.
- [ ] On `/game`: click the headshot a few times; counter goes up.
- [ ] Drag the headshot ~120px right/left → +5 with hearts/tomatoes.
- [ ] Drag up/down → -10 (Now turns red, 👹 appears next to heading).
- [ ] Three ups in a row → full rage storm + -25 + Rage Unlocked badge appears.
- [ ] Drag down past 100 in one run → unicorn flyover.
- [ ] Drag Now to ≤ -100 → hell mode: pulsing red + drifting demons + 💀 Rock Bottom badge.
- [ ] Reset clears Now / in-run achievements / hell mode but keeps Lifetime, secret badges, and rage backoff.
- [ ] Click the "Now" number: 3× free +5, then 10 "no more"s, then "Fiiiiine. +10", then 5 more "no more"s, then "-50" rage.
- [ ] Refresh in hell mode → state restored, hell still on, demons re-spawn.
- [ ] No console errors on /, /about, /projects, /game.

🤖 Generated with [Claude Code](https://claude.com/claude-code)