### PR TITLE
Fix mobile glitches: swipe double-bounce, tap blink, home CTA layout

### DIFF
--- a/_includes/sparkly_header.html
+++ b/_includes/sparkly_header.html
@@ -57,12 +57,12 @@
         <a aria-label="My App Store" target="_blank" href="{{ site.appstore_url }}"><i class="icon fa fa-apple" aria-hidden="true"></i></a>
         {% endif %}
       </div>
-      <div class="header-links">
-        <a class="hero-cta" href="{{ "/game" | relative_url }}">
-          <i class="fa fa-gamepad" aria-hidden="true"></i>
-          Play a game
-        </a>
-      </div>
+  </div>
+  <div class="header-links">
+    <a class="hero-cta" href="{{ "/game" | relative_url }}">
+      <i class="fa fa-gamepad" aria-hidden="true"></i>
+      Play a game
+    </a>
   </div>
   <a class="down" href="#main" data-scroll><i class="icon fa fa-chevron-down" aria-hidden="true"></i></a>
 </section>

--- a/assets/css/game.css
+++ b/assets/css/game.css
@@ -107,6 +107,14 @@
   touch-action: none;
   user-select: none;
   -webkit-user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  -webkit-touch-callout: none;
+}
+.headshot-game__target picture,
+.headshot-game__target img,
+.headshot-game__card {
+  -webkit-tap-highlight-color: transparent;
+  -webkit-touch-callout: none;
 }
 .headshot-game__target:focus-visible .headshot-game__card {
   box-shadow: 0 0 0 3px rgba(40, 91, 177, 0.5);
@@ -130,44 +138,46 @@
   transition: none;
 }
 
+.headshot-game__target.swipe-right .headshot-game__card,
+.headshot-game__target.swipe-left .headshot-game__card,
+.headshot-game__target.swipe-up .headshot-game__card,
+.headshot-game__target.swipe-down .headshot-game__card {
+  transition: none;
+}
 .headshot-game__target.swipe-right .headshot-game__card {
-  animation: swipe-fly-right 0.65s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+  animation: swipe-fly-right 0.55s ease-out forwards;
 }
 .headshot-game__target.swipe-left .headshot-game__card {
-  animation: swipe-fly-left 0.65s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+  animation: swipe-fly-left 0.55s ease-out forwards;
 }
 .headshot-game__target.swipe-up .headshot-game__card {
-  animation: swipe-fly-up 0.65s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+  animation: swipe-fly-up 0.55s ease-out forwards;
 }
 .headshot-game__target.swipe-down .headshot-game__card {
-  animation: swipe-fly-down 0.65s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+  animation: swipe-fly-down 0.55s ease-out forwards;
 }
 @keyframes swipe-fly-right {
-  0%   { transform: translateX(0) rotate(0deg); }
-  35%  { transform: translateX(220px) rotate(22deg); opacity: 0.85; }
-  60%  { transform: translateX(220px) rotate(22deg); opacity: 0; }
-  61%  { transform: translateX(-40px) rotate(-6deg); opacity: 0; }
+  0%   { transform: translateX(0) rotate(0deg); opacity: 1; }
+  60%  { transform: translateX(240px) rotate(18deg); opacity: 0; }
+  61%  { transform: translateX(0) rotate(0deg); opacity: 0; }
   100% { transform: translateX(0) rotate(0deg); opacity: 1; }
 }
 @keyframes swipe-fly-left {
-  0%   { transform: translateX(0) rotate(0deg); }
-  35%  { transform: translateX(-220px) rotate(-22deg); opacity: 0.85; }
-  60%  { transform: translateX(-220px) rotate(-22deg); opacity: 0; }
-  61%  { transform: translateX(40px) rotate(6deg); opacity: 0; }
+  0%   { transform: translateX(0) rotate(0deg); opacity: 1; }
+  60%  { transform: translateX(-240px) rotate(-18deg); opacity: 0; }
+  61%  { transform: translateX(0) rotate(0deg); opacity: 0; }
   100% { transform: translateX(0) rotate(0deg); opacity: 1; }
 }
 @keyframes swipe-fly-up {
-  0%   { transform: translateY(0); }
-  35%  { transform: translateY(-200px); opacity: 0.85; }
-  60%  { transform: translateY(-200px); opacity: 0; }
-  61%  { transform: translateY(40px); opacity: 0; }
+  0%   { transform: translateY(0); opacity: 1; }
+  60%  { transform: translateY(-220px); opacity: 0; }
+  61%  { transform: translateY(0); opacity: 0; }
   100% { transform: translateY(0); opacity: 1; }
 }
 @keyframes swipe-fly-down {
-  0%   { transform: translateY(0); }
-  35%  { transform: translateY(200px); opacity: 0.85; }
-  60%  { transform: translateY(200px); opacity: 0; }
-  61%  { transform: translateY(-40px); opacity: 0; }
+  0%   { transform: translateY(0); opacity: 1; }
+  60%  { transform: translateY(220px); opacity: 0; }
+  61%  { transform: translateY(0); opacity: 0; }
   100% { transform: translateY(0); opacity: 1; }
 }
 

--- a/assets/css/sparkly-header.scss
+++ b/assets/css/sparkly-header.scss
@@ -310,7 +310,12 @@ section#sparkly-header{
 
 section#sparkly-header {
   .header-links {
-    margin-top: 18px;
+    position: absolute;
+    bottom: 80px;
+    left: 50%;
+    transform: translateX(-50%);
+    margin: 0;
+    z-index: 2;
     display: flex;
     justify-content: center;
   }
@@ -332,6 +337,7 @@ section#sparkly-header {
     backdrop-filter: blur(4px);
     -webkit-backdrop-filter: blur(4px);
     transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    -webkit-tap-highlight-color: transparent;
   }
   .hero-cta i {
     font-size: 14px;
@@ -345,6 +351,16 @@ section#sparkly-header {
     transform: translateY(-2px);
     box-shadow: 0 10px 28px rgba(0, 0, 0, 0.3), 0 0 30px rgba(40, 91, 177, 0.4);
     -webkit-text-stroke: 0;
+  }
+
+  @media (max-width: 768px) {
+    .header-links {
+      bottom: 72px;
+    }
+    .hero-cta {
+      font-size: 13px;
+      padding: 8px 16px;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Three mobile fixes reported on the live site:

### 1. Swipe up bounces the image twice (glitchy)
The swipe-fly keyframes had a second motion segment (fly out → drop below center → spring back) that created a visible double-bounce, especially on mobile. The CSS spring-back transition on `.headshot-game__card` was also racing with the start of the swipe animation, since the inline transform was cleared on pointerup at the same time the `swipe-*` class was added.

- Replaced the multi-stage keyframes with a clean fly-out + fade + invisible teleport-back + fade-in.
- Set `transition: none` on the card while a `swipe-*` class is active so the transition can't compete with the animation's first frame.
- Easing changed from spring (`cubic-bezier(0.34, 1.56, 0.64, 1)`) to plain `ease-out` since we no longer need the bouncy overshoot.

### 2. Tap on mobile blinks a square over the circular image
iOS Safari draws a rectangular tap highlight over `<button>` elements that ignores `border-radius`. Added `-webkit-tap-highlight-color: transparent` and `-webkit-touch-callout: none` on the target, the card, and the inner `<picture>`/`<img>`.

### 3. Home "Play a game" CTA broke the click-me prompt on mobile
The CTA was inside `.header`, which is absolutely centered with `transform: translate(-50%, -50%)`. Adding it grew the centered stack vertically, which pushed the headshot up. The `.click-me-prompt` is positioned `top: -185px` relative to the headshot on mobile — once the headshot moved up, the prompt landed above the viewport.

- Moved `.header-links` out of `.header` and into `#sparkly-header` directly.
- Positioned it absolutely near the bottom of the hero (`bottom: 80px` desktop, `bottom: 72px` mobile, above the down arrow).
- Centered hero stack (headshot / title / icons) is back to its pre-CTA height, so the click-me prompt sits where it did before.

## Test plan
- [ ] On mobile, load `/` — confirm "Click me" arrow + bubble are visible above the headshot on first paint, and the "Play a game" pill sits above the down arrow.
- [ ] On `/game` mobile, tap the headshot — confirm no rectangular blue/grey highlight flashes.
- [ ] On `/game` mobile, swipe up — confirm one smooth fly-up + fade, no second downward bounce.
- [ ] On `/game` mobile, swipe right/left/down — same one-motion behavior.
- [ ] No console errors on `/`, `/about`, `/projects`, `/game`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)